### PR TITLE
Add vendor onboarding emails and vendor login page

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,3 +1,13 @@
 MONGODB_URI=mongodb://localhost:27017/credify
 PORT=4000
 CORS_ORIGIN=http://localhost:5173
+
+# Email (SMTP) configuration for sending vendor onboarding emails
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your_smtp_username
+SMTP_PASS=your_smtp_password
+SMTP_FROM="Credify <no-reply@credify.com>"
+
+# Frontend base URL used in emails for links
+APP_BASE_URL=http://localhost:5173

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
     "mongoose": "^8.6.2",
+    "nodemailer": "^6.9.14",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,6 +6,7 @@ import productsRouter from "./routes/products";
 import ordersRouter from "./routes/orders";
 import healthRouter from "./routes/health";
 import verifyRouter from "./routes/verify";
+import vendorsRouter from "./routes/vendors";
 import Product from "./models/Product";
 
 dotenv.config();
@@ -18,6 +19,7 @@ app.use("/api/health", healthRouter);
 app.use("/api/products", productsRouter);
 app.use("/api/orders", ordersRouter);
 app.use("/api/verify-payment", verifyRouter);
+app.use("/api/vendors", vendorsRouter);
 
 const PORT = Number(process.env.PORT || 4000);
 

--- a/backend/src/models/Vendor.ts
+++ b/backend/src/models/Vendor.ts
@@ -1,0 +1,34 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+export interface IVendor extends Document {
+  businessName: string;
+  name: string;
+  email: string;
+  phone?: string;
+  website?: string;
+  businessAddress?: string;
+  concordiumAddress?: string;
+  avalancheAddress?: string;
+  status: "pending" | "active" | "suspended";
+  registrationDate: Date;
+  onboardedBy?: string;
+}
+
+const VendorSchema = new Schema<IVendor>(
+  {
+    businessName: { type: String, required: true },
+    name: { type: String, required: true },
+    email: { type: String, required: true, unique: true, index: true },
+    phone: { type: String },
+    website: { type: String },
+    businessAddress: { type: String },
+    concordiumAddress: { type: String },
+    avalancheAddress: { type: String },
+    status: { type: String, enum: ["pending", "active", "suspended"], default: "active" },
+    registrationDate: { type: Date, default: Date.now },
+    onboardedBy: { type: String }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.models.Vendor || mongoose.model<IVendor>("Vendor", VendorSchema);

--- a/backend/src/routes/vendors.ts
+++ b/backend/src/routes/vendors.ts
@@ -1,0 +1,84 @@
+import { Router } from "express";
+import Vendor from "../models/Vendor";
+import { sendVendorOnboardEmail } from "../services/email";
+
+const router = Router();
+
+router.post("/register", async (req, res) => {
+  try {
+    const { businessName, ownerName, email, phone, website, businessAddress, concordiumAddress, avalancheAddress, onboardedBy } = req.body || {};
+    if (!businessName || !ownerName || !email) return res.status(400).json({ error: "Missing required fields" });
+
+    const existing = await Vendor.findOne({ email });
+    if (existing) {
+      return res.status(200).json({ vendor: existing, message: "Vendor already exists" });
+    }
+
+    const vendor = await Vendor.create({
+      businessName,
+      name: ownerName,
+      email,
+      phone,
+      website,
+      businessAddress,
+      concordiumAddress,
+      avalancheAddress,
+      status: "active",
+      onboardedBy: onboardedBy || "self",
+    });
+
+    try {
+      await sendVendorOnboardEmail(email, ownerName, businessName);
+    } catch (e) {
+      // Don't fail the API if email fails; report warning
+      console.error("Email error:", e);
+    }
+
+    return res.status(201).json({ vendor });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.post("/onboard", async (req, res) => {
+  // Admin-triggered onboarding
+  try {
+    const { businessName, name, email, concordiumAddress, phone } = req.body || {};
+    if (!businessName || !name || !email) return res.status(400).json({ error: "Missing required fields" });
+
+    const vendor = await Vendor.findOneAndUpdate(
+      { email },
+      { businessName, name, email, concordiumAddress, phone, status: "active", onboardedBy: "admin" },
+      { upsert: true, new: true }
+    );
+
+    try {
+      await sendVendorOnboardEmail(email, name, businessName);
+    } catch (e) {
+      console.error("Email error:", e);
+    }
+
+    return res.json({ vendor });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+router.post("/login", async (req, res) => {
+  try {
+    const { email } = req.body || {};
+    if (!email) return res.status(400).json({ error: "Email is required" });
+    const vendor = await Vendor.findOne({ email });
+    if (!vendor) return res.status(404).json({ error: "Vendor not found" });
+    // Demo session token (not secure). In real app, issue JWT and set httpOnly cookie.
+    const session = Buffer.from(`${vendor._id}:${Date.now()}`).toString("base64");
+    return res.json({ ok: true, vendor: { id: vendor._id, businessName: vendor.businessName, name: vendor.name, email: vendor.email }, session });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/backend/src/services/email.ts
+++ b/backend/src/services/email.ts
@@ -1,0 +1,50 @@
+import nodemailer from "nodemailer";
+
+const required = (name: string, value: string | undefined) => {
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+  return value;
+};
+
+export async function sendVendorOnboardEmail(to: string, vendorName: string, businessName: string) {
+  const host = required("SMTP_HOST", process.env.SMTP_HOST);
+  const port = Number(process.env.SMTP_PORT || 587);
+  const user = required("SMTP_USER", process.env.SMTP_USER);
+  const pass = required("SMTP_PASS", process.env.SMTP_PASS);
+  const from = process.env.SMTP_FROM || `Credify <no-reply@credify.local>`;
+  const appBaseUrl = process.env.APP_BASE_URL || "http://localhost:5173";
+
+  const transporter = nodemailer.createTransport({
+    host,
+    port,
+    secure: port === 465,
+    auth: { user, pass },
+  });
+
+  const loginUrl = `${appBaseUrl}/vendor-login`;
+
+  const html = `
+  <div style="font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Arial, sans-serif; line-height:1.6; color:#0f172a">
+    <h2>Welcome to Credify, ${vendorName}!</h2>
+    <p>Your vendor account for <strong>${businessName}</strong> has been successfully onboarded.</p>
+    <p>You can access your vendor dashboard anytime:</p>
+    <p>
+      <a href="${loginUrl}" style="background:#2563eb;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none;display:inline-block">Go to Vendor Login</a>
+    </p>
+    <p>Steps to get started:</p>
+    <ol>
+      <li>Visit <a href="${loginUrl}">${loginUrl}</a></li>
+      <li>Sign in with your registered email address</li>
+      <li>Start adding products and managing your orders</li>
+    </ol>
+    <p>If you did not request this, please ignore this email.</p>
+    <hr/>
+    <p style="font-size:12px;color:#475569">This message was sent automatically by Credify.</p>
+  </div>`;
+
+  await transporter.sendMail({
+    from,
+    to,
+    subject: "You're onboarded on Credify — Vendor access",
+    html,
+  });
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ import { SellerDashboard } from "@/pages/SellerDashboard";
 import { AdminDashboard } from "@/pages/AdminDashboard";
 import { VendorRegistration } from "@/pages/VendorRegistration";
 import { OrderTracking } from "@/pages/OrderTracking";
+import AdminLogin from "@/pages/AdminLogin";
+import VendorLogin from "@/pages/VendorLogin";
 
 export default function App() {
   const location = useLocation();
@@ -51,8 +53,10 @@ export default function App() {
                 <Route path="/" element={<HomePage />} />
                 <Route path="/marketplace" element={<MarketplacePage />} />
                 <Route path="/seller" element={<SellerDashboard />} />
-                <Route path="/admin-dashboard" element={<AdminDashboard />} />
-                <Route path="/vendor-registration" element={<VendorRegistration />} />
+                <Route path="/vendor-login" element={<VendorLogin />} />
+                <Route path="/admin-login" element={<AdminLogin onLoginSuccess={() => { window.location.href = '/admin-dashboard'; }} onNavigateHome={() => { window.location.href = '/'; }} />} />
+                <Route path="/admin-dashboard" element={<AdminDashboard onNavigateHome={() => { window.location.href = '/'; }} onLogout={() => { window.location.href = '/admin-login'; }} />} />
+                <Route path="/vendor-registration" element={<VendorRegistration onNavigateHome={() => { window.location.href = '/'; }} />} />
                 <Route path="/order-tracking" element={<OrderTracking />} />
                 <Route path="/credify-admin-secure" element={<Navigate to="/admin-login" replace />} />
                 <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -49,14 +49,22 @@ export function Navigation() {
             >
               Marketplace
             </NavLink>
-            {/* <NavLink 
-              to="/order-tracking" 
+            <NavLink 
+              to="/vendor-login" 
               className={({ isActive }) => 
                 `text-sm hover:text-primary transition-colors font-medium ${isActive ? 'text-primary' : ''}`
               }
             >
-              Track Your Order
-            </NavLink> */}
+              Vendor Login
+            </NavLink>
+            <NavLink 
+              to="/credify-admin-secure" 
+              className={({ isActive }) => 
+                `text-sm hover:text-primary transition-colors font-medium ${isActive ? 'text-primary' : ''}`
+              }
+            >
+              Admin
+            </NavLink>
             <WalletConnection />
           </div>
           
@@ -97,15 +105,24 @@ export function Navigation() {
               >
                 Marketplace
               </NavLink>
-              {/* <NavLink 
-                to="/order-tracking" 
+              <NavLink 
+                to="/vendor-login" 
                 className={({ isActive }) => 
                   `text-sm hover:text-primary transition-colors py-2 text-left font-medium ${isActive ? 'text-primary' : ''}`
                 }
                 onClick={() => setMobileMenuOpen(false)}
               >
-                Track Your Order
-              </NavLink> */}
+                Vendor Login
+              </NavLink>
+              <NavLink 
+                to="/credify-admin-secure" 
+                className={({ isActive }) => 
+                  `text-sm hover:text-primary transition-colors py-2 text-left font-medium ${isActive ? 'text-primary' : ''}`
+                }
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                Admin
+              </NavLink>
               <div className="py-2">
                 <WalletConnection />
               </div>

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -163,6 +163,23 @@ export function AdminDashboard({ onNavigateHome, onLogout }: AdminDashboardProps
     
     // In a real app, you'd save to your database here
     localStorage.setItem(`vendor_${vendorData.id}`, JSON.stringify(vendorData));
+
+    // Persist to backend and trigger confirmation email to vendor
+    try {
+      await fetch('/api/vendors/onboard', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          businessName: vendorData.businessName,
+          name: vendorData.name,
+          email: vendorData.email,
+          concordiumAddress: vendorData.concordiumAddress,
+          phone: vendorData.phone
+        })
+      });
+    } catch (e) {
+      console.warn('Backend vendor onboard failed:', e);
+    }
     
     // Reset form and close dialog
     setNewVendor({

--- a/src/pages/VendorLogin.tsx
+++ b/src/pages/VendorLogin.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Shield, Loader2, LogIn } from 'lucide-react';
+
+export default function VendorLogin() {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/vendors/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Login failed');
+      }
+      const data = await res.json();
+      localStorage.setItem('vendor_session', data.session);
+      localStorage.setItem('vendor_email', data.vendor?.email || email);
+      window.location.href = '/seller';
+    } catch (e: any) {
+      setError(e.message || 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-background via-background to-primary/5 flex items-center justify-center p-4">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-8">
+          <div className="w-12 h-12 rounded-lg bg-primary flex items-center justify-center mx-auto mb-3">
+            <Shield className="w-6 h-6 text-white" />
+          </div>
+          <h1 className="text-2xl font-bold">Vendor Login</h1>
+          <p className="text-muted-foreground">Access your seller dashboard</p>
+        </div>
+
+        <Card className="p-6">
+          <form onSubmit={handleLogin} className="space-y-4">
+            {error && (
+              <Alert variant="destructive">
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="email">Email address</Label>
+              <Input id="email" type="email" value={email} onChange={e => setEmail(e.target.value)} placeholder="you@business.com" required />
+            </div>
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? (<><Loader2 className="w-4 h-4 mr-2 animate-spin" />Signing in...</>) : (<><LogIn className="w-4 h-4 mr-2" />Sign In</>)}
+            </Button>
+          </form>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/VendorRegistration.tsx
+++ b/src/pages/VendorRegistration.tsx
@@ -316,8 +316,30 @@ export function VendorRegistration({ onNavigateHome }: VendorRegistrationProps) 
       productsCount: 0
     };
 
-    // Save to localStorage (replace with database call in production)
+    // Save to localStorage (temporary)
     localStorage.setItem(`vendor_${vendorData.id}`, JSON.stringify(vendorData));
+
+    // Persist to backend and trigger confirmation email
+    try {
+      await fetch('/api/vendors/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          businessName: formData.businessName,
+          ownerName: formData.ownerName,
+          email: formData.email,
+          phone: formData.phone,
+          website: formData.website,
+          businessAddress: formData.businessAddress,
+          concordiumAddress: formData.concordiumAddress,
+          avalancheAddress: formData.avalancheAddress,
+          onboardedBy: 'self'
+        })
+      });
+    } catch (e) {
+      console.warn('Backend vendor registration failed:', e);
+    }
+
     console.log('Vendor registration saved:', vendorData);
   };
 


### PR DESCRIPTION
- Backend: Vendor model, /api/vendors (register, onboard, login), SMTP email service, env vars added.\n- Frontend: /vendor-login page, /admin-login route fix, nav links.\n- Vendor and admin onboarding now trigger confirmation emails with login steps.\n\nConfigure backend/.env with SMTP_* and APP_BASE_URL for email sending.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/c45984d6-6354-4ad6-9b65-b61d53e3ccbc/task/77424ab2-1ab8-4f69-9d48-cc5afe541646))