### PR TITLE
Fix Netlify build: switch to npm

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,10 +1,9 @@
 [build]
-  command = "bun run build"
+  command = "npm ci && npm run build"
   publish = "dist"
 
 [build.environment]
   NODE_VERSION = "20"
-  NPM_FLAGS = "--version"
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
Use npm ci && npm run build in netlify.toml so deploys work without Bun. Previously bun run build failed if Bun isn’t installed on Netlify.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/c45984d6-6354-4ad6-9b65-b61d53e3ccbc/task/77424ab2-1ab8-4f69-9d48-cc5afe541646))