### PR TITLE
Netlify: use npm in all contexts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,13 +11,13 @@
   status = 200
 
 [context.production]
-  command = "bun run build"
+  command = "npm ci && npm run build"
 
 [context.deploy-preview]
-  command = "bun run build"
+  command = "npm ci && npm run build"
 
 [context.branch-deploy]
-  command = "bun run build"
+  command = "npm ci && npm run build"
 
 [[headers]]
   for = "/assets/*"


### PR DESCRIPTION
Switch all Netlify contexts to npm ci && npm run build to avoid Bun requirement. This should fix failing deploys.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/c45984d6-6354-4ad6-9b65-b61d53e3ccbc/task/77424ab2-1ab8-4f69-9d48-cc5afe541646))