### PR TITLE
Netlify: switch to npm install (no lockfile)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm ci && npm run build"
+  command = "npm install --no-fund --no-audit && npm run build"
   publish = "dist"
 
 [build.environment]
@@ -11,13 +11,13 @@
   status = 200
 
 [context.production]
-  command = "npm ci && npm run build"
+  command = "npm install --no-fund --no-audit && npm run build"
 
 [context.deploy-preview]
-  command = "npm ci && npm run build"
+  command = "npm install --no-fund --no-audit && npm run build"
 
 [context.branch-deploy]
-  command = "npm ci && npm run build"
+  command = "npm install --no-fund --no-audit && npm run build"
 
 [[headers]]
   for = "/assets/*"


### PR DESCRIPTION
Builds failed because npm ci requires package-lock.json, which this repo doesn’t have (uses bun.lock). Switch to npm install in all contexts.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/c45984d6-6354-4ad6-9b65-b61d53e3ccbc/task/77424ab2-1ab8-4f69-9d48-cc5afe541646))