### PR TITLE
Netlify: install with --legacy-peer-deps

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "npm install --no-fund --no-audit && npm run build"
+  command = "npm install --legacy-peer-deps --no-fund --no-audit && npm run build"
   publish = "dist"
 
 [build.environment]
@@ -11,13 +11,13 @@
   status = 200
 
 [context.production]
-  command = "npm install --no-fund --no-audit && npm run build"
+  command = "npm install --legacy-peer-deps --no-fund --no-audit && npm run build"
 
 [context.deploy-preview]
-  command = "npm install --no-fund --no-audit && npm run build"
+  command = "npm install --legacy-peer-deps --no-fund --no-audit && npm run build"
 
 [context.branch-deploy]
-  command = "npm install --no-fund --no-audit && npm run build"
+  command = "npm install --legacy-peer-deps --no-fund --no-audit && npm run build"
 
 [[headers]]
   for = "/assets/*"


### PR DESCRIPTION
NPM install fails due to peer dependency mismatch between @concordium packages. Add --legacy-peer-deps to unblock build. Also fixed async error earlier.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/c45984d6-6354-4ad6-9b65-b61d53e3ccbc/task/77424ab2-1ab8-4f69-9d48-cc5afe541646))