### PR TITLE
Remove Admin link from navigation

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -57,14 +57,6 @@ export function Navigation() {
             >
               Vendor Login
             </NavLink>
-            <NavLink 
-              to="/credify-admin-secure" 
-              className={({ isActive }) => 
-                `text-sm hover:text-primary transition-colors font-medium ${isActive ? 'text-primary' : ''}`
-              }
-            >
-              Admin
-            </NavLink>
             <WalletConnection />
           </div>
           
@@ -113,15 +105,6 @@ export function Navigation() {
                 onClick={() => setMobileMenuOpen(false)}
               >
                 Vendor Login
-              </NavLink>
-              <NavLink 
-                to="/credify-admin-secure" 
-                className={({ isActive }) => 
-                  `text-sm hover:text-primary transition-colors py-2 text-left font-medium ${isActive ? 'text-primary' : ''}`
-                }
-                onClick={() => setMobileMenuOpen(false)}
-              >
-                Admin
               </NavLink>
               <div className="py-2">
                 <WalletConnection />


### PR DESCRIPTION
Hide admin entry point from the navbar. Admin login remains accessible via the secret path /credify-admin-secure (which redirects to /admin-login).

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/c45984d6-6354-4ad6-9b65-b61d53e3ccbc/task/77424ab2-1ab8-4f69-9d48-cc5afe541646))