### PR TITLE
Switch to USDT (Avalanche): env rename + client + labels; FEE_BPS=500

### DIFF
--- a/avalanche/.env.example
+++ b/avalanche/.env.example
@@ -1,16 +1,13 @@
-# Avalanche mainnet RPC
+# Avalanche mainnet deployment configuration
 AVALANCHE_RPC_URL=https://api.avax.network/ext/bc/C/rpc
+DEPLOYER_KEY=
+OWNER_ADDRESS=0x086ad0D712e0Ad0A61032372C344190972B5e4d8
+FEE_RECIPIENT=0x65b7a307a7e67e38840b91f9a36bf8dfe6e02901
+FEE_BPS=500
+USDT=0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7
+SNOWTRACE_API_KEY=
 
-# Private key of deployer (use a Gnosis Safe for ownership post-deploy)
-DEPLOYER_KEY=0xYourPrivateKey
-
-# Optional ownership / fee settings
-OWNER_ADDRESS=0xOwnerMultisig
-FEE_RECIPIENT=0xFeeRecipient
-FEE_BPS=200
-
-# USDC address on Avalanche (native USDC.e)
-USDC=0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E
-
-# Snowtrace API key (for contract verification)
-SNOWTRACE_API_KEY=your_snowtrace_api_key
+# Vendor mint helper (optional)
+VENDORPASS=
+MINT_TO=
+MINT_URI=

--- a/avalanche/scripts/deploy.js
+++ b/avalanche/scripts/deploy.js
@@ -7,8 +7,8 @@ async function main() {
 
   const owner = process.env.OWNER_ADDRESS || deployer.address;
   const feeRecipient = process.env.FEE_RECIPIENT || deployer.address;
-  const feeBps = Number(process.env.FEE_BPS || 200); // 2%
-  const USDC = process.env.USDC || "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E"; // Avalanche USDC
+  const feeBps = Number(process.env.FEE_BPS || 500); // 5%
+  const USDT = process.env.USDT || "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7"; // Avalanche USDT
 
   const VendorPass = await ethers.getContractFactory("VendorPass");
   const vendorPass = await VendorPass.deploy(owner);
@@ -16,7 +16,7 @@ async function main() {
   console.log("VendorPass:", await vendorPass.getAddress());
 
   const Escrow = await ethers.getContractFactory("EscrowUSDC");
-  const escrow = await Escrow.deploy(USDC, await vendorPass.getAddress(), feeRecipient, feeBps, owner);
+  const escrow = await Escrow.deploy(USDT, await vendorPass.getAddress(), feeRecipient, feeBps, owner);
   await escrow.waitForDeployment();
   console.log("EscrowUSDC:", await escrow.getAddress());
 

--- a/src/components/ShoppingCart.tsx
+++ b/src/components/ShoppingCart.tsx
@@ -499,7 +499,7 @@ export function CartSheet() {
                   onClick={handleAVAXCheckout}
                 >
                   <Zap className="w-4 h-4 mr-2" />
-                  Pay with USDC (Avalanche) {!avalancheState.isConnected && '(Connect MetaMask)'}
+                  Pay with USDT (Avalanche) {!avalancheState.isConnected && '(Connect MetaMask)'}
                 </Button>
                 
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/src/lib/avalanche.ts
+++ b/src/lib/avalanche.ts
@@ -3,7 +3,7 @@ import { ethers } from "ethers";
 export const AVALANCHE = {
   chainId: 43114,
   rpcUrl: import.meta.env.VITE_RPC_URL || "https://api.avax.network/ext/bc/C/rpc",
-  usdc: import.meta.env.VITE_USDC,
+  usdt: import.meta.env.VITE_USDT,
   escrow: import.meta.env.VITE_ESCROW,
   vendorPass: import.meta.env.VITE_VENDORPASS
 };
@@ -46,10 +46,10 @@ export async function isVendor(addr: string): Promise<boolean> {
   return vp.isVendor(addr);
 }
 
-export async function approveUsdcIfNeeded(owner: string, amount: bigint) {
-  if (!AVALANCHE.usdc || !AVALANCHE.escrow) throw new Error("Missing USDC/ESCROW env");
+export async function approveUsdtIfNeeded(owner: string, amount: bigint) {
+  if (!AVALANCHE.usdt || !AVALANCHE.escrow) throw new Error("Missing USDT/ESCROW env");
   const signer = await getSigner();
-  const erc20 = new ethers.Contract(AVALANCHE.usdc, ERC20_ABI, signer);
+  const erc20 = new ethers.Contract(AVALANCHE.usdt, ERC20_ABI, signer);
   const allowance: bigint = await erc20.allowance(owner, AVALANCHE.escrow);
   if (allowance < amount) {
     await (await erc20.approve(AVALANCHE.escrow, amount)).wait();
@@ -57,11 +57,11 @@ export async function approveUsdcIfNeeded(owner: string, amount: bigint) {
 }
 
 export async function createEscrowOrder(vendor: string, usdAmount: number, orderRef: string) {
-  if (!AVALANCHE.escrow || !AVALANCHE.usdc) throw new Error("Missing env");
+  if (!AVALANCHE.escrow || !AVALANCHE.usdt) throw new Error("Missing env");
   const signer = await getSigner();
   const addr = await signer.getAddress();
-  const amount: bigint = BigInt(Math.round(usdAmount * 1_000_000)); // USDC 6 decimals
-  await approveUsdcIfNeeded(addr, amount);
+  const amount: bigint = BigInt(Math.round(usdAmount * 1_000_000)); // USDT 6 decimals
+  await approveUsdtIfNeeded(addr, amount);
   const escrow = new ethers.Contract(AVALANCHE.escrow, ESCROW_ABI, signer);
   const tx = await escrow.createOrder(vendor, amount, orderRef);
   return tx.wait();


### PR DESCRIPTION
- Frontend env var renamed: VITE_USDC -> VITE_USDT (use Avalanche USDT 0x9702…A8c7)
- src/lib/avalanche.ts now uses USDT and updates approve/create escrow flow
- ShoppingCart: button label changed to 'Pay with USDT (Avalanche)'
- deploy script: default FEE_BPS=500 and USDT address fallback; added avalanche/.env.example

OWNER_ADDRESS: 0x086ad0D712e0Ad0A61032372C344190972B5e4d8
FEE_RECIPIENT: 0x65b7a307a7e67e38840b91f9a36bf8dfe6e02901
USDT (Avalanche): 0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7

Please review; after merge I’ll wire per-product vendorWallet and sweep Concordium copy.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/b777891c-f555-469a-8ba8-000471db865c/task/e14b1249-51b6-46b7-ba0c-97324fe5338d))