### PR TITLE
Per‑product vendor wallet: schema + checkout uses vendorWallet for escrow

### DIFF
--- a/backend/src/models/Product.ts
+++ b/backend/src/models/Product.ts
@@ -6,6 +6,7 @@ export interface IProduct extends Document {
   price: number;
   currency: "USD" | "EUR" | "CCD";
   images: string[];
+  vendorWallet?: string;
   category: {
     id: string;
     name: string;
@@ -40,6 +41,7 @@ const ProductSchema = new Schema<IProduct>(
     price: { type: Number, required: true },
     currency: { type: String, enum: ["USD", "EUR", "CCD"], default: "USD" },
     images: { type: [String], default: [] },
+    vendorWallet: { type: String, required: false },
     category: {
       id: { type: String, required: true },
       name: { type: String, required: true },

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -24,6 +24,7 @@ export interface Product {
   price: number;
   currency: 'USD' | 'EUR' | 'CCD'; // CCD = Concordium
   images: string[];
+  vendorWallet?: string;
   category: ProductCategory;
   seller: {
     id: string;

--- a/src/components/ShoppingCart.tsx
+++ b/src/components/ShoppingCart.tsx
@@ -294,7 +294,16 @@ export function CartSheet() {
       throw new Error('Avalanche wallet not connected');
     }
     const totalAmount = state.totalAmount + (hasEscrowItems ? state.totalAmount * 0.02 : 0);
-    const vendorAddr = import.meta.env.VITE_DEFAULT_VENDOR || avalancheState.account; // placeholder
+    const vendorWallets = Array.from(new Set(
+      state.items
+        .map((i) => (i.product as any).vendorWallet)
+        .filter((v): v is string => !!v)
+        .map((v) => v.toLowerCase())
+    ));
+    if (vendorWallets.length !== 1) {
+      throw new Error('Cart must contain items from a single vendor with a vendor wallet set');
+    }
+    const vendorAddr = vendorWallets[0];
     const ref = `credify_${Date.now()}`;
     await createEscrowOrder(vendorAddr, totalAmount, ref);
     setOrderRef(ref);


### PR DESCRIPTION
- Add vendorWallet?: string to Product schema (backend) and shared types
- Checkout enforces single-vendor cart and uses product.vendorWallet to escrow
- Integrates with existing Release Escrow button post‑checkout

Note: set vendorWallet on products to a vendor’s wallet (must hold a VendorPass).

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/b777891c-f555-469a-8ba8-000471db865c/task/e14b1249-51b6-46b7-ba0c-97324fe5338d))