### PR TITLE
Remove ConcordiumProvider and CCD code paths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { useEffect } from "react";
 import { AvalancheProvider } from "@/contexts/AvalancheContext";
-import { ConcordiumProvider } from "@/contexts/ConcordiumContext";
+
 import { CartProvider } from "@/contexts/CartContext";
 import { CartSheet } from "@/components/ShoppingCart";
 import { Navigation } from "@/components/Navigation";
@@ -41,8 +41,7 @@ export default function App() {
 
   return (
     <AvalancheProvider>
-      <ConcordiumProvider>
-        <CartProvider>
+      <CartProvider>
           <ErrorBoundary>
             <div className="relative">
               <Navigation />
@@ -65,7 +64,6 @@ export default function App() {
             </div>
           </ErrorBoundary>
         </CartProvider>
-      </ConcordiumProvider>
     </AvalancheProvider>
   );
 }


### PR DESCRIPTION
- App.tsx: drop ConcordiumProvider wrapper (Avalanche only)
- ShoppingCart: remove CCD payment code and Concordium hook; checkout now supports Card and USDT (Avalanche) only

This trims unused code and reduces bundle surface.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/b777891c-f555-469a-8ba8-000471db865c/task/e14b1249-51b6-46b7-ba0c-97324fe5338d))