### PR TITLE
Fix crash: stub useConcordium when provider is absent

### DIFF
--- a/src/contexts/ConcordiumContext.tsx
+++ b/src/contexts/ConcordiumContext.tsx
@@ -410,10 +410,18 @@ export function ConcordiumProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export function useConcordium() {
+export function useConcordium(): ConcordiumContextType {
   const context = useContext(ConcordiumContext);
   if (context === undefined) {
-    throw new Error('useConcordium must be used within a ConcordiumProvider');
+    return {
+      state: initialState,
+      connect: async () => { throw new Error('Concordium is disabled'); },
+      disconnect: () => {},
+      signMessage: async () => null,
+      verifyAge: async () => false,
+      verifyIdentity: async () => false,
+      getAccountAddress: () => null,
+    } as ConcordiumContextType;
   }
   return context;
 }


### PR DESCRIPTION
- Updates useConcordium to return a safe no-op stub when not wrapped in a provider
- Prevents runtime error 'useConcordium must be used within a ConcordiumProvider' on pages still importing the hook

This is a temporary safety net; we already removed Concordium usage from core flows.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/b777891c-f555-469a-8ba8-000471db865c/task/e14b1249-51b6-46b7-ba0c-97324fe5338d))